### PR TITLE
Make save button container sticky in settings

### DIFF
--- a/scripts/config.php
+++ b/scripts/config.php
@@ -1238,7 +1238,7 @@ function upload_settings() {
 		</div>
 
 		<div class="card" style="margin-top: 2em;">
-			<?php echo '<button style="margin-top: 2em;" type="submit" name="save">' . L::config_save_button . '</button>'; ?>
+            <?php echo '<button style="margin-top: 2em; position: sticky; bottom: 0; background-color: var(--cbg)" type="submit" name="save">' . L::config_save_button . '</button>'; ?>
 		</div>
 
 	</form>


### PR DESCRIPTION
Little tweak on the settings page to make it easier to use. This style change makes the save button stick to the bottom of the screen until you reach the bottom of the container. Should make it easier to update the settings and also removes the need to have multiple save buttons on the page.