### PR TITLE
Typo in display.py crashes display update loop

### DIFF
--- a/scripts/display.py
+++ b/scripts/display.py
@@ -569,7 +569,7 @@ class DISPLAY(object):
 					oCF.write("\n".join(Lines))
 
 					if hidden_info:
-						LoCF.write(f"\nset:hidden={hidden_info}")
+						oCF.write(f"\nset:hidden={hidden_info}")
 
 				if self.hardware_ready:
 					self.show(Lines, self.get_statusbar())


### PR DESCRIPTION
Found out while assembling the box that after a short time the display stops working. After debugging the hardware I had a look at the code and found this typo. Working as intended now.