### PR TITLE
Docs, document buttons compatibility Waveshare board

### DIFF
--- a/scripts/buttons.cfg
+++ b/scripts/buttons.cfg
@@ -4,6 +4,6 @@
 
 5=up,6=down,17=left,27=right
 6=up,13=down,19=left,26=right
-6=up,19=down,5=left,26=right
+6=up,19=down,5=left,26=right:SH1106 WAVESHARE OLED display HAT, Joystick
 19=up,6=down,26=left,5=right:ST7735 WAVESHARE LCD display HAT, Joystick
 19=up,6=down,21=left,16=right:ST7735 WAVESHARE LCD display HAT, Button


### PR DESCRIPTION
I spent some time getting this Waveshare OLED screen working, 
https://www.waveshare.com/product/raspberry-pi/displays/oled/1.3inch-oled-hat.htm

For anyone else in the future:


Display Driver should be`SH1106`